### PR TITLE
Protocol: Keep listener listening if we don't trust the upstream address

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -2,6 +2,8 @@ package proxyproto
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -9,11 +11,15 @@ import (
 	"time"
 )
 
-// DefaultReadHeaderTimeout is how long header processing waits for header to
-// be read from the wire, if Listener.ReaderHeaderTimeout is not set.
-// It's kept as a global variable so to make it easier to find and override,
-// e.g. go build -ldflags -X "github.com/pires/go-proxyproto.DefaultReadHeaderTimeout=1s"
-var DefaultReadHeaderTimeout = 10 * time.Second
+var (
+	// DefaultReadHeaderTimeout is how long header processing waits for header to
+	// be read from the wire, if Listener.ReaderHeaderTimeout is not set.
+	// It's kept as a global variable so to make it easier to find and override,
+	// e.g. go build -ldflags -X "github.com/pires/go-proxyproto.DefaultReadHeaderTimeout=1s"
+	DefaultReadHeaderTimeout = 10 * time.Second
+
+	ErrInvalidUpstream = fmt.Errorf("proxyproto: upstream connection address not trusted for PROXY information")
+)
 
 // Listener is used to wrap an underlying listener,
 // whose connections may be using the HAProxy Proxy Protocol.
@@ -60,41 +66,50 @@ func ValidateHeader(v Validator) func(*Conn) {
 
 // Accept waits for and returns the next connection to the listener.
 func (p *Listener) Accept() (net.Conn, error) {
-	// Get the underlying connection
-	conn, err := p.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-
-	proxyHeaderPolicy := USE
-	if p.Policy != nil {
-		proxyHeaderPolicy, err = p.Policy(conn.RemoteAddr())
+	for {
+		// Get the underlying connection
+		conn, err := p.Listener.Accept()
 		if err != nil {
-			// can't decide the policy, we can't accept the connection
-			conn.Close()
 			return nil, err
 		}
-		// Handle a connection as a regular one
-		if proxyHeaderPolicy == SKIP {
-			return conn, nil
+
+		proxyHeaderPolicy := USE
+		if p.Policy != nil {
+			proxyHeaderPolicy, err = p.Policy(conn.RemoteAddr())
+			if err != nil {
+				// can't decide the policy, we can't accept the connection
+				conn.Close()
+
+				if errors.Is(err, ErrInvalidUpstream) {
+					// keep listening for other connections
+					continue
+				}
+
+				return nil, err
+			}
+
+			// Handle a connection as a regular one
+			if proxyHeaderPolicy == SKIP {
+				return conn, nil
+			}
 		}
+
+		newConn := NewConn(
+			conn,
+			WithPolicy(proxyHeaderPolicy),
+			ValidateHeader(p.ValidateHeader),
+		)
+
+		// If the ReadHeaderTimeout for the listener is unset, use the default timeout.
+		if p.ReadHeaderTimeout == 0 {
+			p.ReadHeaderTimeout = DefaultReadHeaderTimeout
+		}
+
+		// Set the readHeaderTimeout of the new conn to the value of the listener
+		newConn.readHeaderTimeout = p.ReadHeaderTimeout
+
+		return newConn, nil
 	}
-
-	newConn := NewConn(
-		conn,
-		WithPolicy(proxyHeaderPolicy),
-		ValidateHeader(p.ValidateHeader),
-	)
-
-	// If the ReadHeaderTimeout for the listener is unset, use the default timeout.
-	if p.ReadHeaderTimeout == 0 {
-		p.ReadHeaderTimeout = DefaultReadHeaderTimeout
-	}
-
-	// Set the readHeaderTimeout of the new conn to the value of the listener
-	newConn.readHeaderTimeout = p.ReadHeaderTimeout
-
-	return newConn, nil
 }
 
 // Close closes the underlying listener.


### PR DESCRIPTION
This PR is designed to prevent listeners being stopped when an error is returned, if the upstream connection address is not trusted. Instead, we continue to close the connection but now the `Accept` method has a `for` loop to continue looking for other connections to accept.

In using this library we discovered that the listener `Accept` method returning an error caused the listener to be closed and never reopened when trying to serve HTTP endpoints.

The change was based on [github.com/armon/go-proxyproto/](https://github.com/armon/go-proxyproto/blob/master/protocol.go#L70) which does something similar with the loop and checking for a particular type of error.

Notes: 

See: [`net/http/server.go => Serve(l net.Listener)`](https://cs.opensource.google/go/go/+/master:src/net/http/server.go;l=3303)

https://cs.opensource.google/go/go/+/master:src/net/http/server.go;l=3333-3351

```
rw, err := l.Accept()
if err != nil {
	if srv.shuttingDown() {
		return ErrServerClosed
	}
	if ne, ok := err.(net.Error); ok && ne.Temporary() {
		if tempDelay == 0 {
			tempDelay = 5 * time.Millisecond
		} else {
			tempDelay *= 2
		}
		if max := 1 * time.Second; tempDelay > max {
			tempDelay = max
		}
		srv.logf("http: Accept error: %v; retrying in %v", err, tempDelay)
		time.Sleep(tempDelay)
		continue
	}
	return err
}
```

Above we end up returning the `err` at the end, which stops the `Serve` method (so prevents us listening).